### PR TITLE
Polish docs styles and fix typos.

### DIFF
--- a/docs/README_ch.md
+++ b/docs/README_ch.md
@@ -1,15 +1,15 @@
 # Hunter
 
-相关技术文章： [一起玩转Android项目中的字节码](http://quinnchen.cn/2018/09/13/2018-09-13-asm-transform/)
+相关技术文章： [一起玩转Android项目中的字节码](http://quinnchen.cn/2018/09/13/2018-09-13-asm-transform/)。
 
-Hunter是这么一个框架，帮你快速开发插件，在编译过程中修改字节码，它底层基于[ASM](https://asm.ow2.io/) 和 [Gradle Transform API](http://tools.android.com/tech-docs/new-build-system/transform-api)
-实现。在这个框架基础上，我尝试开发了几款实用的插件。你也可以用Hunter开发自己的插件，诸如实现App性能监控（UI，网络等等），加强或修改第三方库以满足你的需求，甚至可以加强、修改Android framework的接口。Hunter本身支持增量、并发编译，所以不用担心使用这一系列插件会增加编译时间。
+Hunter 是这么一个框架，帮你快速开发插件，在编译过程中修改字节码，它底层基于 [ASM](https://asm.ow2.io/) 和 [Gradle Transform API](http://tools.android.com/tech-docs/new-build-system/transform-api)
+实现。在这个框架基础上，我尝试开发了几款实用的插件。你也可以用 Hunter 开发自己的插件，诸如实现 app 性能监控（UI、网络等等），加强或修改第三方库以满足你的需求，甚至可以加强、修改 Android Framework 的接口。Hunter 本身支持增量、并发编译，所以不用担心使用这一系列插件会增加编译时间。
 
 ## 最新版本
 
-Hunter最新版本已经发布到[MavenCentral](https://repo1.maven.org/maven2/cn/quinnchen/hunter/).
+Hunter 最新版本已经发布到 [MavenCentral](https://repo1.maven.org/maven2/cn/quinnchen/hunter/)。
 
-所有 librraies / plugins 都使用同样的最新版本号，可以使用这个版本号替代其他README文档中的LATEST_VERSION_IN_README变量
+所有 libraries / plugins 都使用同样的最新版本号，可以使用这个版本号替代其他 README 文档中的 LATEST_VERSION_IN_README 变量。
 
 ```groovy
 
@@ -17,23 +17,23 @@ Hunter最新版本已经发布到[MavenCentral](https://repo1.maven.org/maven2/c
 
 ```
 
-## 基于Hunter的插件
+## 基于 Hunter 的插件
 
- + [OkHttp-Plugin](https://github.com/Leaking/Hunter/blob/master/README_hunter_okhttp_ch.md): 通过修改字节码的方式hack掉okhttp，为你的应用所有的OkhttpClient设置全局 [Interceptor](https://github.com/square/okhttp/wiki/Interceptors) / [Eventlistener](https://github.com/square/okhttp/wiki/Events) 
-(包括第三方依赖里的OkhttpClient)
- + [Timing-Plugin](https://github.com/Leaking/Hunter/blob/master/README_hunter_timing_ch.md): 帮你监控所有UI线程的执行耗时，并且提供了算法，帮你打印出一个带有每步耗时的堆栈，统计卡顿方法分布，并且提供接口让你选择自己的方式来处理卡顿信息。
- + [Debug-Plugin](https://github.com/Leaking/Hunter/blob/master/README_hunter_debug_ch.md): 只要为指定方法加上某个annotation，就可以帮你打印出这个方法所有输入参数的值，以及返回值，执行时间。这个插件相比JakeWharton的[hugo](https://github.com/JakeWharton/hugo)有很多优点：支持koltin，支持自定义logger，不影响断点调试，支持打印对象toString内容，编译速度更快
- + [LogLine-Plugin](https://github.com/Leaking/Hunter/blob/master/README_hunter_logline_ch.md): 为你的日志加上行号
+ + [OkHttp-Plugin](https://github.com/Leaking/Hunter/blob/master/README_hunter_okhttp_ch.md): 通过修改字节码的方式 hack 掉 OkHttp，为你的应用所有的 OkHttpClient 设置全局 [Interceptor](https://github.com/square/okhttp/wiki/Interceptors) / [Eventlistener](https://github.com/square/okhttp/wiki/Events)
+(包括第三方依赖里的 OkHttpClient)。
+ + [Timing-Plugin](https://github.com/Leaking/Hunter/blob/master/README_hunter_timing_ch.md): 帮你监控所有 UI 线程的执行耗时，并且提供了算法，帮你打印出一个带有每步耗时的堆栈，统计卡顿方法分布，并且提供接口让你选择自己的方式来处理卡顿信息。
+ + [Debug-Plugin](https://github.com/Leaking/Hunter/blob/master/README_hunter_debug_ch.md): 只要为指定方法加上某个 annotation，就可以帮你打印出这个方法所有输入参数的值，以及返回值，执行时间。这个插件相比 JakeWharton 的 [Hugo](https://github.com/JakeWharton/hugo) 有很多优点：支持 Kotlin，支持自定义 logger，不影响断点调试，支持打印对象 toString 内容，编译速度更快。
+ + [LogLine-Plugin](https://github.com/Leaking/Hunter/blob/master/README_hunter_logline_ch.md): 为你的日志加上行号。
 
 
-## TODO 
+## TODO
 
-你可以在这里查看我想继续开发的一些插件 [TODO](https://github.com/Leaking/Hunter/blob/master/docs/TODO.md)，另外，欢迎你提供你宝贵的idea
+你可以在这里查看我想继续开发的一些插件 [TODO](https://github.com/Leaking/Hunter/blob/master/docs/TODO.md)，另外，欢迎你提供你宝贵的 idea。
 
 ## Developer API
-    
-如果想开发基于hunter的gradle插件来修改项目中的字节码，可以参考 [Wiki](https://github.com/Leaking/Hunter/wiki/Developer-API)
-   
+
+如果想开发基于 Hunter 的 Gradle 插件来修改项目中的字节码，可以参考 [wiki](https://github.com/Leaking/Hunter/wiki/Developer-API)。
+
 
 ## 社交工具
 

--- a/docs/README_hunter_debug.md
+++ b/docs/README_hunter_debug.md
@@ -3,8 +3,8 @@
 [中文](https://github.com/Leaking/Hunter/blob/master/README_hunter_debug_ch.md)
 
 
-Hunter-debug is a gradle plugin based on [Hunter](https://github.com/Leaking/Hunter), It's inspired by JakeWharton's [hugo](https://github.com/JakeWharton/hugo), But Hunter-debug
-has some advantages over hugo.
+Hunter-Debug is a gradle plugin based on [Hunter](https://github.com/Leaking/Hunter), It's inspired by JakeWharton's [Hugo](https://github.com/JakeWharton/hugo), But Hunter-Debug
+has some advantages over Hugo.
 
 |       | Hugo     | Hunter-Debug     |
 | ---------- | :-----------:  | :-----------: |
@@ -24,7 +24,7 @@ Add some lines to your build.gradle
 ```groovy
 
 dependencies {
-    implementation 'cn.quinnchen.hunter:hunter-debug-library:${LATEST_VERSION_IN_README}'
+    implementation 'cn.quinnchen.hunter:Hunter-Debug-library:${LATEST_VERSION_IN_README}'
 }
 
 repositories {
@@ -36,12 +36,12 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'cn.quinnchen.hunter:hunter-debug-plugin:${LATEST_VERSION_IN_README}'
+        classpath 'cn.quinnchen.hunter:Hunter-Debug-plugin:${LATEST_VERSION_IN_README}'
         classpath 'cn.quinnchen.hunter:hunter-transform:${LATEST_VERSION_IN_README}'
     }
 }
 
-apply plugin: 'hunter-debug'
+apply plugin: 'Hunter-Debug'
 
 ```
 Simply add @HunterDebug to your methods will print all parameters and costed time, return value.
@@ -60,29 +60,29 @@ private String appendIntAndString(int a, String b) {
 ```
 
 
-```xml 
+```xml
 
 MainActivity: ⇢ appendIntAndString[a="5", b="billions"]
               ⇠ appendIntAndString[0ms]="5 billions"
 
 ```
 
-If you want to print the debug log with your custom logger. You can use `@HunterDebugImpl` instead of `@HunterDebug`, and 
+If you want to print the debug log with your custom logger. You can use `@HunterDebugImpl` instead of `@HunterDebug`, and
 install a custom HunterLoggerHandler to receive the log message, and send it to your custom logger.
 (You can use both `@HunterDebug` and `@HunterDebugImpl` at the same time)
 
-```groovy 
+```groovy
 
 HunterLoggerHandler.installLogImpl(new HunterLoggerHandler(){
     @Override
     protected void log(String tag, String msg) {
-        //you can use your custom logger here
+        // you can use your custom logger here
         YourLog.i(tag, msg);
     }
 });
-        
+
 ```
-With standard logging you can filter Hunter logs in logcat with     
+With standard logging you can filter Hunter logs in logcat with
 ```
 (\s|^)⇢(\s|$)|(\s|^)⇠(\s|$)
 Searches if character ⇢ or ⇠ exists
@@ -93,10 +93,10 @@ Logging works in both debug and release build mode, but you can specify certain 
 ```groovy
 
 debugHunterExt {
-    runVariant = 'DEBUG'  //'DEBUG', 'RELEASE', 'ALWAYS', 'NEVER', The 'ALWAYS' is default value
+    runVariant = 'DEBUG'  // 'DEBUG', 'RELEASE', 'ALWAYS', 'NEVER', The 'ALWAYS' is default value
 }
 
-``` 
+```
 
 
 ## License

--- a/docs/README_hunter_debug_ch.md
+++ b/docs/README_hunter_debug_ch.md
@@ -3,27 +3,27 @@
 [English](https://github.com/Leaking/Hunter/blob/master/README_hunter_debug.md)
 
 
-Hunter-debug是基于[Hunter](https://github.com/Leaking/Hunter)开发的，灵感来自于JakeWharton's [hugo](https://github.com/JakeWharton/hugo)，不过相比之下，Hunter-debug有以下优点
+Hunter-Debug 是基于 [Hunter](https://github.com/Leaking/Hunter) 开发的，灵感来自于 Jake Wharton 的 [Hugo](https://github.com/JakeWharton/hugo)，不过相比之下，Hunter-Debug 有以下优点：
 
 |       | Hugo     | Hunter-Debug     |
 | ---------- | :-----------:  | :-----------: |
-| 支持kotlin     | no     | yes     |
-| 自定义logger     | no     | yes     |
-| 对象输出toString     | no     | yes     |
+| 支持 Kotlin     | no     | yes     |
+| 自定义 logger     | no     | yes     |
+| 对象输出 toString     | no     | yes     |
 | 编译速度     | 一般     | 快     |
 
 
-Hunter-Debug是用ASM修改字节码，而非使用AspectJ，所以自然会更快。
+Hunter-Debug 是用 ASM 修改字节码，而非使用 AspectJ，所以自然会更快。
 
 ## 快速引入
 
-在build.gradle中添加以下依赖
+在 build.gradle 中添加以下依赖：
 
 
 ```groovy
 
 dependencies {
-    implementation 'cn.quinnchen.hunter:hunter-debug-library:${LATEST_VERSION_IN_README}'
+    implementation 'cn.quinnchen.hunter:Hunter-Debug-library:${LATEST_VERSION_IN_README}'
 }
 
 repositories {
@@ -35,15 +35,15 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'cn.quinnchen.hunter:hunter-debug-plugin:${LATEST_VERSION_IN_README}'
+        classpath 'cn.quinnchen.hunter:Hunter-Debug-plugin:${LATEST_VERSION_IN_README}'
         classpath 'cn.quinnchen.hunter:hunter-transform:${LATEST_VERSION_IN_README}'
     }
 }
 
-apply plugin: 'hunter-debug'
+apply plugin: 'Hunter-Debug'
 
 ```
-在某个方法开头添加注解@HunterDebug，就会打印方法参数，以及方法返回值，还有方法耗时。
+在某个方法开头添加注解 `@HunterDebug`，就会打印方法参数，以及方法返回值，还有方法耗时。
 
 比如
 
@@ -59,38 +59,38 @@ private String appendIntAndString(int a, String b) {
 ```
 
 
-```xml 
+```xml
 
 MainActivity: ⇢ appendIntAndString[a="5", b="billions"]
               ⇠ appendIntAndString[0ms]="5 billions"
 
 ```
-如果你想将输出结果使用你们项目中自定义的logger处理，可以使用
-`@HunterDebugImpl`，然后设置一个接受日志输出的`HunterLoggerHandler`
+如果你想将输出结果使用你们项目中自定义的 logger 处理，可以使用
+`@HunterDebugImpl`，然后设置一个接受日志输出的`HunterLoggerHandler`：
 
-```groovy 
+```groovy
 
 HunterLoggerHandler.installLogImpl(new HunterLoggerHandler(){
     @Override
     protected void log(String tag, String msg) {
-        //you can use your custom logger here
+        // 在这里使用你自己的日志输出方式
         YourLog.i(tag, msg);
     }
 });
-        
+
 ```
 
-如果你只想在debug模式下使用该插件，则可以这样设置，
+如果你只想在 debug 模式下使用该插件，则可以这样设置：
 
 ```groovy
 
 debugHunterExt {
-    runVariant = 'DEBUG'  //'DEBUG', 'RELEASE', 'ALWAYS', 'NEVER', The 'ALWAYS' is default value
+    runVariant = 'DEBUG'  // 'DEBUG', 'RELEASE', 'ALWAYS', 'NEVER', 默认为 'ALWAYS'
 }
 
-``` 
+```
 
-欢迎引入Hunter-Debug到你项目中使用，使用过程有遇到什么问题，或者有什么建议，都可以提issue或者邮件联系我，只要有空我会第一时间回应。
+欢迎引入 Hunter-Debug 到你项目中使用，使用过程有遇到什么问题，或者有什么建议，都可以提 issue 或者邮件联系我，只要有空我会第一时间回应。
 
 ## License
 

--- a/docs/README_hunter_logline_ch.md
+++ b/docs/README_hunter_logline_ch.md
@@ -2,11 +2,11 @@
 
 [English](https://github.com/Leaking/Hunter/blob/master/README_hunter_logline.md)
 
-这个插件会为你每行日志添加行号，可以帮你更快定位日志，尤其有时候你在一个Java文件中不同地方，打印了一样的日志。
+这个插件会为你每行日志添加行号，可以帮你更快定位日志，尤其当你在一个 Java 文件中不同地方，打印了一样的日志时会更有帮助。
 
 ## 快速引入
 
-在build.gradle中添加以下依赖
+在 build.gradle 中添加以下依赖：
 
 ```groovy
 
@@ -29,31 +29,31 @@ buildscript {
 }
 
 apply plugin: 'hunter-linelog'
-    
+
 ```
 
 
 
-未使用这个插件时打印的日志
+未使用这个插件时打印的日志：
 
 ```java
 
 I/MainActivity: onCreate
 
 ```
-使用插件后的日志
+使用插件后的日志：
 
 ```java
 
 I/MainActivity[21]: onCreate
 
-```  
-如果你只想在debug模式下使用该插件，则可以这样设置，
+```
+如果你只想在 debug 模式下使用该插件，则可以这样设置：
 
 ```groovy
 
 linelogHunterExt {
-    runVariant = 'DEBUG'  //'DEBUG', 'RELEASE', 'ALWAYS', 'NEVER', The 'ALWAYS' is default value
+    runVariant = 'DEBUG'  // 'DEBUG', 'RELEASE', 'ALWAYS', 'NEVER', 默认为 'ALWAYS'
 }
 
-``` 
+```

--- a/docs/README_hunter_okhttp.md
+++ b/docs/README_hunter_okhttp.md
@@ -2,12 +2,12 @@
 
 [中文](https://github.com/Leaking/Hunter/blob/master/README_hunter_okhttp_ch.md)
 
-Maybe your project have serveral OkhttpClients，you need to add your custom Interceptor/EventListener/Dns 
-to every OkhttpClients one by one. But some OkhttpClients come from 3rd library, and you can't add
+Maybe your project have serveral OkHttpClients，you need to add your custom Interceptor/EventListener/Dns
+to every OkHttpClients one by one. But some OkHttpClients come from 3rd library, and you can't add
  your custom Interceptor/EventListener/Dns to them. I have filed a [issue](https://github.com/square/okhttp/issues/4228) about this problem to Okhttp team.
- 
+
 OkHttp-Plugin can help you to achieve it, you can set a global Interceptor/EventListener/Dns to your all
-OkhttpClients.
+OkHttpClients.
 
 ## How to use it
 
@@ -35,7 +35,7 @@ buildscript {
 }
 
 apply plugin: 'hunter-okhttp'
-    
+
 ```
 
 
@@ -44,7 +44,7 @@ apply plugin: 'hunter-okhttp'
 OkHttpHooker.installEventListenerFactory(CustomGlobalEventListener.FACTORY);
 OkHttpHooker.installDns(new CustomGlobalDns());
 OkHttpHooker.installInterceptor(new CustomGlobalInterceptor());
-        
+
 ```
 
 I recommend you to upgrade your okhttp to 3.11 or above, it almost costs nothing. If you want to use this plugin for okhttp below 3.11, please

--- a/docs/README_hunter_okhttp_ch.md
+++ b/docs/README_hunter_okhttp_ch.md
@@ -2,20 +2,18 @@
 
 [English](https://github.com/Leaking/Hunter/blob/master/README_hunter_okhttp.md)
 
-一个稍微上规模的项目，很大可能有很多个OkhttpClient散落在各个业务中，那么如果你想使用Interceptor/EventListener做网络监控，或者设置自定义Dns，
-那就很麻烦，需要一处处为所有OkhttpClient设置Interceptor/EventListener/Dns，而且有些第三方依赖库里的OkhttpClient你是无能为力的。当然，你可以
-反射去处理，但是这会遇到很多麻烦。
+一个稍微上规模的项目，很大可能有很多个 OkHttpClient 散落在各个业务中，那么如果你想使用 Interceptor / EventListener 做网络监控，或者设置自定义 DNS，
+那就很麻烦，需要一处处为所有 OkHttpClient 设置 Interceptor / EventListener / Dns，而且有些第三方依赖库里的 OkHttpClient 你是无能为力的。当然，你可以用反射去处理，但是这会遇到很多麻烦。
 
-我在Okhtp提过类似问题的[issue](https://github.com/square/okhttp/issues/4228) 
- 
-OkHttp-Plugin 这个插件就可以帮忙你解决这个问题，让你两三句代码就可以为所有OkhttpClient设置全局的Interceptor/EventListener/Dns，方便你做进一步的网络监控、管理。
+我向 OkHttp 提过类似的 [issue](https://github.com/square/okhttp/issues/4228)。
+
+OkHttp-Plugin 这个插件就可以帮忙你解决这个问题，让你两三句代码就可以为所有 OkHttpClient 设置全局的 Interceptor / EventListener / Dns，方便你做进一步的网络监控、管理。
 
 ## 快速引入
 
-在build.gradle中添加以下依赖
+在 build.gradle 中添加以下依赖：
 
 ```groovy
-
 
 dependencies {
     implementation 'com.quinn.hunter:hunter-okhttp-library:1.2.0'
@@ -51,7 +49,7 @@ buildscript {
 }
 
 apply plugin: 'hunter-okhttp'
-    
+
 ```
 
 
@@ -60,6 +58,7 @@ apply plugin: 'hunter-okhttp'
 OkHttpHooker.installEventListenerFactory(CustomGlobalEventListener.FACTORY);
 OkHttpHooker.installDns(new CustomGlobalDns());
 OkHttpHooker.installInterceptor(new CustomGlobalInterceptor());
-        
+
 ```
-由于EventListener是okhttp 3.11才引入的，所以上面的使用方式需要okhttp3.11=及以上才行，如果你低于3.11，请查看这个wiki  [wiki for okhttp-below-3.11](https://github.com/Leaking/Hunter/wiki/Okhttp-below-3.11)。不过，升级okhttp的成本很低，建议还是把项目中的okhttp升级上来。
+由于 EventListener 是 OkHttp 3.11 才引入的，所以上面的使用方式需要 OkHttp 3.11 及以上才行，如果你的版本低于 3.11，请查看这个 [wiki](https://github.com/Leaking/Hunter/wiki/Okhttp-below-3.11)。不过，升级 OkHttp 的成本很低，建议还是把项目中的 OkHttp 升级上来。
+

--- a/docs/README_hunter_timing_ch.md
+++ b/docs/README_hunter_timing_ch.md
@@ -2,14 +2,14 @@
 
 [English](https://github.com/Leaking/Hunter/blob/master/README_hunter_timing.md)
 
-timing-plugin可以帮你监控UI线程的卡顿方法，并且提供了算法，帮你dump出所有卡顿堆栈，堆栈中每一步的耗时都会标出，让你一眼就可以看出卡顿的位置。
+Timing-Plugin 可以帮你监控 UI 线程的卡顿方法，并且提供了算法，帮你 dump 出所有卡顿堆栈，堆栈中每一步的耗时都会标出，让你一眼就可以看出卡顿的位置。
 
-并且提供了接口，让你按你自己方式来处理卡顿信息。
+并且提供了接口，让你按你自己的方式来处理卡顿信息。
 
 
 ## 如何使用
 
-在你的build.gradle中引入以下依赖
+在你的 build.gradle 中引入以下依赖：
 
 ```groovy
 
@@ -32,10 +32,10 @@ buildscript {
 }
 
 apply plugin: 'hunter-timing'
-    
+
 ```
 
-Hunter-Timing 提供内置了一个默认的BlockHandler帮你打印卡顿的方法，也提供了其他两种BlockHandler实现
+Hunter-Timing 提供内置了一个默认的 `BlockHandler` 帮你打印卡顿的方法，也提供了其他两种 `BlockHandler` 实现：
 
 ```java
 IBlockHandler customBlockManager = new RankingBlockHandler();
@@ -43,7 +43,7 @@ BlockManager.installBlockManager(customBlockManager);
 
 ```
 
-Dump卡顿分析结果
+Dump 卡顿分析结果：
 
 ```java
 
@@ -51,7 +51,7 @@ customBlockManager.dump()
 
 ```
 
-即将打印卡顿方法相关统计，分为平均值排行和次数排行
+即将打印卡顿方法相关统计，分为平均值排行和次数排行：
 
 
 ```xml
@@ -71,44 +71,44 @@ customBlockManager.dump()
     com.quinn.hunter.timing.DataSource.readFileContent: 1(Avg : 1400.0ms)
     com.quinn.hunter.timing.DataSource.<init>: 1(Avg : 801.0ms)
     com.quinn.hunter.timing.DataSource.<clinit>: 1(Avg : 804.0ms)
-    
-   
+
+
 ```
 
-而如果你使用另一个IBlockHandler的实现，StacktraceBlockHandler，则即将等得到以下结果，一个个带有每步执行时间的堆栈
+而如果你使用另一个 `IBlockHandler` 的实现——`StacktraceBlockHandler`，则即将等得到以下结果，一个个带有每步执行时间的堆栈：
 
 ```xml
-    
+
     ----BlockStackTrace----Total 5----
     Block StackTrace 0
     com.quinn.hunter.timing.DataSource.readFileContent costed 1400ms
     com.quinn.hunter.timing.DataSource.modifyAndMoveFile costed 2403ms
     com.quinn.hunter.timing.MainActivity.onCreate is root
-    
+
     Block StackTrace 1
     com.quinn.hunter.timing.DataSource.saveHugeFileToDisk costed 1000ms
     com.quinn.hunter.timing.DataSource.modifyAndMoveFile costed 2403ms
     com.quinn.hunter.timing.MainActivity.onCreate is root
-    
+
     Block StackTrace 2
     com.quinn.hunter.timing.DataSource.<init> costed 800ms
     com.quinn.hunter.timing.DataSource.<clinit> costed 801ms
     com.quinn.hunter.timing.DataSource.getInstance is root
-    
+
     Block StackTrace 3
     com.quinn.hunter.timing.DataSource.getUserName costed 901ms
     com.quinn.hunter.timing.MainActivity.onCreate is root
-    
+
     Block StackTrace 4
     com.quinn.hunter.timing.DataSource.saveHugeFileToDisk costed 1000ms
     com.quinn.hunter.timing.MainActivity.onCreate is root
-  
-    
-```
-你可以可以实现自己的IBlockHandler，按自己的需求分析卡顿情况
-    
 
-另外，这个插件还提供一个扩展，带有几个配置参数    
+
+```
+你可以可以实现自己的 `IBlockHandler`，按自己的需求分析卡顿情况.
+
+
+另外，这个插件还提供一个扩展，带有几个配置参数:
 
 ```groovy
 
@@ -121,16 +121,15 @@ timingHunterExt {
 ```
 **runVariant**
 
-这个值默认是ALWAYS，表示这个插件在debug和release下都会修改字节码，这个配置全部有四个可选值，DEBUG, RELEASE, ALWAYS, NEVER，
-每个值的含义，顾名思义，相信大家都懂。另外，每个基于Hunter的插件的Extension基本都提供了这个runVariant配置。
+这个值默认是 `ALWAYS`，表示这个插件在 debug 和 release 下都会修改字节码，这个配置全部有四个可选值，`DEBUG`、`RELEASE`、`ALWAYS`、`NEVER`，
+顾名思义，相信大家都懂。另外，每个基于 Hunter 的插件的 Extension 基本都提供了这个 `runVariant` 配置。
 
 **whitelist**
 
-白名单列表，只对这些包名下的class做监控，此处包名支持字符串前缀匹配
+白名单列表，只对这些包名下的 class 做监控，此处包名支持字符串前缀匹配。
 
 **blacklist**
 
-黑名单列表，对这些包名下的class之外的所有class做监控，此处包名支持字符串前缀匹配
+黑名单列表，对这些包名下的 class 之外的所有 class 做监控，此处包名支持字符串前缀匹配。
 
-黑名单模式和白名单模式是互斥的，建议只用黑名单配置，或者只用白名单配置，如果两个都填了，则黑名单参数会被忽略
-
+黑名单模式和白名单模式是互斥的，建议只用黑名单配置，或者只用白名单配置，如果两个都填了，则黑名单参数会被忽略。


### PR DESCRIPTION
- Add consistent whitespaces between CJK and non-CJK characters.
- Fix inproper capitalizations (eg. "OkhttpClient" -> "OkHttpClient").
- Polish language for Chinese docs (eg. "我在Okhtp提过类似问题的issue" -> "我向 OkHttp 提过类似的 issue").
- Add trailing colons or periods (： / 。) for sentences and remove redundant whitespace characters.